### PR TITLE
[Upload]Add feature support for MinIO 提供开源对象存储服务MinIO的支持（新文件上传实现）

### DIFF
--- a/src/pdfdeal/FileTools/Img/MinIO.py
+++ b/src/pdfdeal/FileTools/Img/MinIO.py
@@ -1,54 +1,84 @@
 import os
 from minio import Minio, S3Error
-class MINIO:
+import logging
+from urllib.parse import urlparse
+import json
 
+
+class MINIO:
     def __init__(self, minio_address, minio_admin, minio_password, bucket_name):
         # 通过ip 账号 密码 连接minio server
-        # Http连接 将secure设置为False
-        self.minioClient = Minio(endpoint=minio_address,
-                                 access_key=minio_admin,
-                                 secret_key=minio_password,
-                                 secure=False,
-                                 )
+        # 根据地址自动判断是否使用安全连接
+        parsed_url = urlparse(minio_address)
+        secure = parsed_url.scheme == "https"
+        self.minioClient = Minio(
+            endpoint=parsed_url.netloc,
+            access_key=minio_admin,
+            secret_key=minio_password,
+            secure=secure,
+        )
         self.bucket_name = bucket_name
+        self.minio_address = minio_address
 
     def upload_file(self, local_file_path, remote_file_path):
         """Upload a file
 
-               Args:
-                   local_file_path (str): The path of the local file to upload.
-                   remote_file_path (str): The path of the remote file to upload to.
+        Args:
+            local_file_path (str): The path of the local file to upload.
+            remote_file_path (str): The path of the remote file to upload to.
 
-               Returns:
-                   tuple: A tuple containing the URL of the uploaded file and a boolean indicating whether the upload was successful.
+        Returns:
+            tuple: A tuple containing the URL of the uploaded file and a boolean indicating whether the upload was successful.
         """
-        # 桶是否存在 不存在则新建
+        # 检查桶是否存在，不存在则新建并设置为公开只读
         check_bucket = self.minioClient.bucket_exists(self.bucket_name)
         if not check_bucket:
             self.minioClient.make_bucket(self.bucket_name)
+            # 设置桶策略为公开只读
+            policy = {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "*"},
+                        "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
+                        "Resource": f"arn:aws:s3:::{self.bucket_name}",
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "*"},
+                        "Action": "s3:GetObject",
+                        "Resource": f"arn:aws:s3:::{self.bucket_name}/*",
+                    },
+                ],
+            }
+            self.minioClient.set_bucket_policy(self.bucket_name, json.dumps(policy))
         try:
             path, file_name = os.path.split(local_file_path)
-            self.minioClient.fput_object(bucket_name=self.bucket_name,
-                                         object_name=file_name,
-                                         file_path=local_file_path)
-            remote_file_path = "http://127.0.0.1:9000" + '/' + self.bucket_name + '/' + file_name
+            self.minioClient.fput_object(
+                bucket_name=self.bucket_name,
+                object_name=file_name,
+                file_path=local_file_path,
+            )
+            parsed_url = urlparse(self.minio_address)
+            scheme = parsed_url.scheme or "http"
+            remote_file_path = (
+                f"{scheme}://{parsed_url.netloc}/{self.bucket_name}/{file_name}"
+            )
             return (remote_file_path, True)
         except FileNotFoundError as err:
-            print('upload_failed: ' + str(err))
+            logging.exception(f"Error to upload the file: {local_file_path}, {err}")
+            return err, False
         except S3Error as err:
-            print("upload_failed:", err)
+            logging.exception(f"Error to upload the file: {local_file_path}, {err}")
+            return err, False
+
 
 def Min(minio_address, minio_admin, minio_password, bucket_name) -> callable:
-        Min_uploader = MINIO(
-        minio_address = minio_address,
-        minio_admin = minio_admin,
-        minio_password = minio_password,
-        bucket_name = bucket_name)
-        return Min_uploader.upload_file
-
-
-
-
-
-
-
+    Min_uploader = MINIO(
+        minio_address=minio_address,
+        minio_admin=minio_admin,
+        minio_password=minio_password,
+        bucket_name=bucket_name,
+    )
+    return Min_uploader.upload_file

--- a/src/pdfdeal/FileTools/Img/MinIO.py
+++ b/src/pdfdeal/FileTools/Img/MinIO.py
@@ -1,0 +1,61 @@
+
+
+import os
+from minio import Minio, S3Error
+
+
+# MinIO使用bucket（桶）来组织对象。
+# bucket类似于文件夹或目录，其中每个bucket可以容纳任意数量的对象。
+class MINIO:
+
+    def __init__(self, minio_address, minio_admin, minio_password, bucket_name):
+        # 通过ip 账号 密码 连接minio server
+        # Http连接 将secure设置为False
+        self.minioClient = Minio(endpoint=minio_address,
+                                 access_key=minio_admin,
+                                 secret_key=minio_password,
+                                 secure=False,
+                                 )
+        self.bucket_name = bucket_name
+
+    def upload_file(self, local_file_path, remote_file_path):
+        """Upload a file
+
+               Args:
+                   local_file_path (str): The path of the local file to upload.
+                   remote_file_path (str): The path of the remote file to upload to.
+
+               Returns:
+                   tuple: A tuple containing the URL of the uploaded file and a boolean indicating whether the upload was successful.
+        """
+        # 桶是否存在 不存在则新建
+        check_bucket = self.minioClient.bucket_exists(self.bucket_name)
+        if not check_bucket:
+            self.minioClient.make_bucket(self.bucket_name)
+
+        try:
+            path, file_name = os.path.split(local_file_path)
+            self.minioClient.fput_object(bucket_name=self.bucket_name,
+                                         object_name=file_name,
+                                         file_path=local_file_path)
+            remote_file_path = "http://127.0.0.1:9000" + '/' + self.bucket_name + '/' + file_name
+            return (remote_file_path, True)
+        except FileNotFoundError as err:
+            print('upload_failed: ' + str(err))
+        except S3Error as err:
+            print("upload_failed:", err)
+
+def MiN(minio_address, minio_admin, minio_password, bucket_name) -> callable:
+        Min_uploader = MINIO(
+        minio_address = minio_address,
+        minio_admin = minio_admin,
+        minio_password = minio_password,
+        bucket_name = bucket_name)
+        return Min_uploader.upload_file
+
+
+
+
+
+
+

--- a/src/pdfdeal/FileTools/Img/MinIO.py
+++ b/src/pdfdeal/FileTools/Img/MinIO.py
@@ -1,11 +1,5 @@
-
-
 import os
 from minio import Minio, S3Error
-
-
-# MinIO使用bucket（桶）来组织对象。
-# bucket类似于文件夹或目录，其中每个bucket可以容纳任意数量的对象。
 class MINIO:
 
     def __init__(self, minio_address, minio_admin, minio_password, bucket_name):
@@ -32,7 +26,6 @@ class MINIO:
         check_bucket = self.minioClient.bucket_exists(self.bucket_name)
         if not check_bucket:
             self.minioClient.make_bucket(self.bucket_name)
-
         try:
             path, file_name = os.path.split(local_file_path)
             self.minioClient.fput_object(bucket_name=self.bucket_name,
@@ -45,7 +38,7 @@ class MINIO:
         except S3Error as err:
             print("upload_failed:", err)
 
-def MiN(minio_address, minio_admin, minio_password, bucket_name) -> callable:
+def Min(minio_address, minio_admin, minio_password, bucket_name) -> callable:
         Min_uploader = MINIO(
         minio_address = minio_address,
         minio_admin = minio_admin,


### PR DESCRIPTION
# PR

# 本地部署开源MinIO对象存储服务器对图片上传支持
# 可以让图片存储至本地对象存储服务，并以URL预览

## 1  Docker本地搭建MinIO服务

拉取minio镜像

```python
docker pull minio/minio
```

创建容器

```python
docker run -p 9000:9000 -p 9090:9090 \
--name minio \
-d --restart=always \
-e "MINIO_ACCESS_KEY=minioadmin" \
-e "MINIO_SECRET_KEY=minioadmin" \
-v /data/minio/data:/data \
-v /data/minio/conf:/root/.minio \
minio/minio server \
/data --console-address ":9090" -address ":9000"
```

进入控制台

```python
127.0.0.1:9090
```

创建桶后

1. 进入[bucke](https://so.csdn.net/so/search?q=bucket&spm=1001.2101.3001.7020)的配置页面,首先将 Access Policy设置为private，再点击Anonymous（配置匿名访问的）
2. 进入页面后，配置只读[访问权限](https://so.csdn.net/so/search?q=%E8%AE%BF%E9%97%AE%E6%9D%83%E9%99%90&spm=1001.2101.3001.7020)，prefix按照提示输入就好
3. 保存之后，它的Access Policy会自动变为custom，我们就能直接通过网址来访问该bucket里面的文件内容。

访问文件网址为：ip:address/bucket的名字/文件的名字

例如：http://127.0.0.1:9000/images/1728633636468.jpg

具体操作参考：[https://blog.csdn.net/destin223/article/details/134110194](https://blog.csdn.net/destin223/article/details/134110194)

## 2 如何上传文件

请首先导入函数并使用您的MinIO管理员账户、密码、IP和bucket进行初始化。

```python
from pdfdeal.FileTools.Img.MINIO import Min
```

`Min`函数需要以下参数进行初始化：

- `minio_address`：您的MINIO服务IP地址，若默认设置部署在本地请输入：`127.0.0.1:9000`
- `minio_admin`：您的MINIO服务管理员账户名，若默认设置则为：`minioadmin`
- `minio_password`：您的MINIO服务管理员密码，若默认设置则为：`minioadmin`
- `bucket_name`：您要上传的的Bucket的名称

示例：

```python
from MinIO import Min
from pdfdeal.file_tools import md_replace_imgs

miupload = Min(
    minio_address = "127.0.0.1:9000",
    minio_admin = "minioadmin",
    minio_password = "minioadmin",
    bucket_name = 'images'  
)
md_replace_imgs(
    mdfile="Output/huxb12138/huxb12138.md",
    replace=miupload,
    threads=5,
)
# 或者您希望替换指定路径中所有MD文档的图片
# mds_replace_imgs(
#     path="Output",
#     replace=miupload,
#     threads=5,
# )
```
